### PR TITLE
CASMPET-7221 update docker-kubectl version to 1.24.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.5] - 2024-09-13
+### Added
+### Change
+- CASMPET-7221
+  - Update docker-kubectl to 1.24.17 for CSM 1.6
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [0.11.4] - 2024-09-02
 ### Added
 ### Change

--- a/kubernetes/cray-dhcp-kea/Chart.yaml
+++ b/kubernetes/cray-dhcp-kea/Chart.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023 Hewlett Packard Enterprise Development LP
 apiVersion: v2
 name: cray-dhcp-kea
-version: 0.11.4
+version: 0.11.5
 
 description: Kubernetes resources for cray-dhcp-kea
 home: https://github.com/Cray-HPE/cray-dhcp-kea
@@ -18,9 +18,9 @@ maintainers:
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
   - name: Management Network
     url: https://github.com/orgs/Cray-HPE/teams/management-network
-appVersion: 0.11.4
+appVersion: 0.11.5
 annotations:
   artifacthub.io/images: |
     - name: cray-dhcp-kea
-      image: artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.4
+      image: artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.11.5
   artifacthub.io/license: MIT

--- a/kubernetes/cray-dhcp-kea/values.yaml
+++ b/kubernetes/cray-dhcp-kea/values.yaml
@@ -9,8 +9,8 @@
 global:
   chart:
     name: cray-dhcp-kea
-    version: 0.11.4
-  appVersion: 0.11.4
+    version: 0.11.5
+  appVersion: 0.11.5
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea
@@ -19,7 +19,7 @@ image:
 kubectl:
   image:
     repository: &kubectlRepository artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: &kubectlTag 1.19.15
+    tag: &kubectlTag 1.24.17
     pullPolicy: &kubectlPullPolicy IfNotPresent
 
 nmnLoadBalancerIp: 10.92.100.222


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

HAVE NOT TESTED

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

